### PR TITLE
eval_client module

### DIFF
--- a/synorchestrator/_mypath.py
+++ b/synorchestrator/_mypath.py
@@ -1,7 +1,0 @@
-import os
-import sys
-
-# temp solution to update local Python path
-# TODO: create setup.py to build library
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(os.path.join(SCRIPT_DIR,"."))

--- a/synorchestrator/eval_client.py/client.py
+++ b/synorchestrator/eval_client.py/client.py
@@ -1,0 +1,39 @@
+
+
+def _configure_queue():
+    """
+    Configure external properties of a Synapse evaluation queue,
+    either based on a config file (YAML) or set of key-value pairs;
+    if the latter, save configuration to config file.
+    """
+    pass
+
+def create_queue(...):
+    """
+    Create (and configure) a new Synapse evaluation queue.
+    """
+    pass
+
+def update_queue(...):
+    """
+    Update properties or configuration for an evaluation queue.
+    """
+    pass
+
+def create_submission(...):
+    """
+    Create a new submission for an evaluation queue.
+    """
+    pass
+
+def get_submissions():
+    """
+    Retrieve submission bundles for an evaluation queue.
+    """
+    pass
+
+def list_submissions():
+    """
+    List submissions for an evaluation queue.
+    """
+    pass

--- a/synorchestrator/eval_client.py/client.py
+++ b/synorchestrator/eval_client.py/client.py
@@ -1,15 +1,15 @@
 import synapseclient
 import os
 import logging
-
+import yml
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
-CONFIG_FILE = os.path.join(os.path.expanduser('~'), '.evaluationConfig')
+CONFIG_FILE = os.path.join(os.path.expanduser('~'), './evals.yml')
 
 syn = synapseclient.login()
 
-def _configure_queue():
+def _configure_queue(evalId, configuration = None):
     """
     Configure external properties of a Synapse evaluation queue,
     either based on a config file (YAML) or set of key-value pairs;
@@ -18,10 +18,15 @@ def _configure_queue():
     quotaKeys = ['roundDurationMillis','submissionLimit','firstRoundStart','numberOfRounds']
     try:
         evaluation = syn.getEvaluation(evalId)
-        quota = {key:challenge_config[evalId].get(key) for key in quotaKeys if challenge_config[evalId].get(key) != "None"}
-        evaluation.quota = quota
-        if storeEvalConfig:    
+        if configuration is not None:
+            quota = {key:challenge_config[evalId].get(key) for key in configuration if challenge_config[evalId].get(key) != "None"}
+            evaluation.quota = quota  
             syn.store(evaluation)
+            with open(CONFIG_FILE,"r") as stream:
+                evalConfig = yaml.load(stream)
+            evalConfig
+            data_loaded[]
+
     except Exception as exception:
         logger.error("The evaluation queue id provided: %s, make sure your firstRoundStart configuration is in quotes or it will be read in as a datetime object" % evalId)
         raise ValueError

--- a/synorchestrator/eval_client.py/client.py
+++ b/synorchestrator/eval_client.py/client.py
@@ -1,4 +1,13 @@
+import synapseclient
+import os
+import logging
 
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
+CONFIG_FILE = os.path.join(os.path.expanduser('~'), '.evaluationConfig')
+
+syn = synapseclient.login()
 
 def _configure_queue():
     """
@@ -6,34 +15,63 @@ def _configure_queue():
     either based on a config file (YAML) or set of key-value pairs;
     if the latter, save configuration to config file.
     """
-    pass
+    quotaKeys = ['roundDurationMillis','submissionLimit','firstRoundStart','numberOfRounds']
+    try:
+        evaluation = syn.getEvaluation(evalId)
+        quota = {key:challenge_config[evalId].get(key) for key in quotaKeys if challenge_config[evalId].get(key) != "None"}
+        evaluation.quota = quota
+        if storeEvalConfig:    
+            syn.store(evaluation)
+    except Exception as exception:
+        logger.error("The evaluation queue id provided: %s, make sure your firstRoundStart configuration is in quotes or it will be read in as a datetime object" % evalId)
+        raise ValueError
+    return(evaluation)
 
 def create_queue(...):
     """
     Create (and configure) a new Synapse evaluation queue.
     """
-    pass
+
+    evalEnt = synapseclient.Evaluation(name="name",description="description",contentSource="parentId",submissionReceiptMessage="message",submissionInstructionsMessage="instructions")
+    syn.store(evalEnt)
+
 
 def update_queue(...):
     """
     Update properties or configuration for an evaluation queue.
     """
-    pass
+
+    evalEnt = syn.getEvaluation(evalId)
+    syn.store(evalEnt)
+
 
 def create_submission(...):
     """
     Create a new submission for an evaluation queue.
     """
+
     pass
 
-def get_submissions():
+def get_submissions(evaluation, status):
     """
     Retrieve submission bundles for an evaluation queue.
     """
-    pass
+    if isinstance(evaluation, basestring):
+        evaluation = syn.getEvaluation(evaluation)
+    return(syn.getSubmissionBundles(evaluation, status=status))
 
-def list_submissions():
+
+def list_submissions(evaluation, status):
     """
     List submissions for an evaluation queue.
     """
-    pass
+
+    if isinstance(evaluation, basestring):
+        evaluation = syn.getEvaluation(evaluation)
+    print '\n\nSubmissions for: %s %s' % (evaluation.id, evaluation.name.encode('utf-8'))
+    print '-' * 60
+
+    for submission, status in get_submissions(evaluation, status):
+        print submission.id, submission.createdOn, status.status, submission.name.encode('utf-8'), submission.userId
+
+

--- a/synorchestrator/eval_client.py/client.py
+++ b/synorchestrator/eval_client.py/client.py
@@ -5,8 +5,8 @@ import yml
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
-CONFIG_FILE = os.path.join(os.path.expanduser('~'), './evals.yml')
-
+CONFIG_FILE = os.path.join(os.path.expanduser('~'), '.orchestratorConfig')
+EVALUATION_CONFIG = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'eval.config')
 syn = synapseclient.login()
 
 def _configure_queue(evalId, configuration = None):
@@ -15,29 +15,31 @@ def _configure_queue(evalId, configuration = None):
     either based on a config file (YAML) or set of key-value pairs;
     if the latter, save configuration to config file.
     """
+
     quotaKeys = ['roundDurationMillis','submissionLimit','firstRoundStart','numberOfRounds']
     try:
         evaluation = syn.getEvaluation(evalId)
         if configuration is not None:
-            quota = {key:challenge_config[evalId].get(key) for key in configuration if challenge_config[evalId].get(key) != "None"}
-            evaluation.quota = quota  
+            quota = {key:configuration.get(key) for key in quotaKeys}
+            evaluation.quota = quota
             syn.store(evaluation)
-            with open(CONFIG_FILE,"r") as stream:
+            with open(EVALUATION_CONFIG,"r") as stream:
                 evalConfig = yaml.load(stream)
-            evalConfig
-            data_loaded[]
-
+            if evalConfig.get(evalId) is None:
+                evalConfig[evalId] = quota
+            with open(EVALUATION_CONFIG,"w") as stream:
+                yaml.dump(evalConfig, stream, default_flow_style=False)
     except Exception as exception:
         logger.error("The evaluation queue id provided: %s, make sure your firstRoundStart configuration is in quotes or it will be read in as a datetime object" % evalId)
         raise ValueError
     return(evaluation)
 
-def create_queue(...):
+def create_queue(evaluation_name, description, contentSource, submissionReceiptMessage, submissionInstructionsMessage):
     """
     Create (and configure) a new Synapse evaluation queue.
     """
 
-    evalEnt = synapseclient.Evaluation(name="name",description="description",contentSource="parentId",submissionReceiptMessage="message",submissionInstructionsMessage="instructions")
+    evalEnt = synapseclient.Evaluation(name=evaluation_name,description=description,contentSource=contentSource,submissionReceiptMessage=submissionReceiptMessage,submissionInstructionsMessage=submissionInstructionsMessage)
     syn.store(evalEnt)
 
 


### PR DESCRIPTION
Figure out role(s) of `eval_client` module for interacting with Synapse evaluation queues: map out classes/methods, get something working. **Note:** a lot of the functionality here should be fairly similar to what's provided in `scripts/challenge.py` (really just a lightweight wrapper around `synapseclient` for evaluation and submission endpoints).